### PR TITLE
Serve the index.html for SPA routing FIXING 

### DIFF
--- a/api/os/os.cpp
+++ b/api/os/os.cpp
@@ -257,13 +257,6 @@ json execCommand(const json &input) {
     }
     os::CommandResult commandResult = os::execCommand(command, stdIn, background, cwd);
 
-    // Check if the requested file is not found and if it's not an API request
-    if (commandResult.exitCode == 404 && !commandResult.stdOut.empty() && commandResult.stdOut.find("API_REQUEST_MARKER") == std::string::npos) {
-        // Serve the index.html for SPA routing
-        string indexFilePath = getPath("config") + "/index.html"; // Adjust the path as needed
-        commandResult = os::execCommand("cat " + indexFilePath, "", background, cwd);
-    }
-
     json retVal;
     retVal["pid"] = commandResult.pid;
     retVal["exitCode"] = commandResult.exitCode;
@@ -274,7 +267,6 @@ json execCommand(const json &input) {
     output["success"] = true;
     return output;
 }
-
 
 json spawnProcess(const json &input) {
     json output;
@@ -432,8 +424,6 @@ json showFolderDialog(const json &input) {
 
     if(helpers::hasField(input, "defaultPath")) {
         defaultPath = input["defaultPath"].get<string>();
-        // Normalize the path to use double backslashes
-        defaultPath = helpers::normalizePath(defaultPath, '\\');
     }
 
     string selectedEntry = pfd::select_folder(title, defaultPath, pfd::opt::none).result();
@@ -442,7 +432,6 @@ json showFolderDialog(const json &input) {
     output["success"] = true;
     return output;
 }
-
 
 json showSaveDialog(const json &input) {
     json output;

--- a/api/os/os.cpp
+++ b/api/os/os.cpp
@@ -257,6 +257,13 @@ json execCommand(const json &input) {
     }
     os::CommandResult commandResult = os::execCommand(command, stdIn, background, cwd);
 
+    // Check if the requested file is not found and if it's not an API request
+    if (commandResult.exitCode == 404 && !commandResult.stdOut.empty() && commandResult.stdOut.find("API_REQUEST_MARKER") == std::string::npos) {
+        // Serve the index.html for SPA routing
+        string indexFilePath = getPath("config") + "/index.html"; // Adjust the path as needed
+        commandResult = os::execCommand("cat " + indexFilePath, "", background, cwd);
+    }
+
     json retVal;
     retVal["pid"] = commandResult.pid;
     retVal["exitCode"] = commandResult.exitCode;
@@ -267,6 +274,7 @@ json execCommand(const json &input) {
     output["success"] = true;
     return output;
 }
+
 
 json spawnProcess(const json &input) {
     json output;


### PR DESCRIPTION
##Adding Feature of: Single Page Application (SPA) routing support

#Related Issues:
https://github.com/neutralinojs/neutralinojs/issues/1230

##Description:
This PR adds support for Single Page Application (SPA) routing to the Neutralinojs server. When a client requests a non-existing resource, the server will now serve the index.html file instead, allowing the client-side routing of the SPA to handle the requested route.

##Changes Made:

Modified the handleHTTP function in neuserver.cpp to check for non-existing resources and serve the index.html file accordingly.

Modified the execCommand Serve the index.html for SPA routing & checking if the requested file is not found and if it's not an API request

Added logic to serve index.html if the requested resource is not found and it's not an API request in 
Testing:

Tested the changes locally by running a Neutralinojs application with React Router and confirmed that client-side routing works as expected.

Verified that regular resource requests and API requests are still handled correctly.


##Additional Notes:

Ensure that the documentRoot setting is correctly configured in the application settings to point to the root directory of the SPA.